### PR TITLE
Addition of reference architecture to landscape site

### DIFF
--- a/ui/common/src/components/ItemModalContent.tsx
+++ b/ui/common/src/components/ItemModalContent.tsx
@@ -250,7 +250,7 @@ export const ItemModalContent = (props: Props) => {
                 <th class={`text-center ${AuditsCol}`} scope="col">
                 Clicks</th>
                 <th class={`text-center ${AuditsCol}`} scope="col">Updated At</th>
-                  <th class="text-center" scope="col">Url</th>
+                  <th class={`text-center`} scope="col">Url</th>
                 </tr>
               </thead>
               <tbody>

--- a/ui/common/src/components/ItemModalContent.tsx
+++ b/ui/common/src/components/ItemModalContent.tsx
@@ -248,7 +248,7 @@ export const ItemModalContent = (props: Props) => {
                 <tr>
                 <th class={`text-center ${AuditsColMd}`} scope="col">Name</th>
                 <th class={`text-center ${AuditsCol}`} scope="col">
-                Clicks</th>
+                Forks</th>
                 <th class={`text-center ${AuditsCol}`} scope="col">Updated At</th>
                   <th class={`text-center`} scope="col">Url</th>
                 </tr>
@@ -539,7 +539,7 @@ export const ItemModalContent = (props: Props) => {
             </div>
           </div>
         </div>
-
+        
         {/* Description */}
         <div class={`mt-4 text-muted ${Description}`}>{description()}</div>
 

--- a/ui/common/src/components/ItemModalContent.tsx
+++ b/ui/common/src/components/ItemModalContent.tsx
@@ -250,7 +250,7 @@ export const ItemModalContent = (props: Props) => {
                 <th class={`text-center ${AuditsCol}`} scope="col">
                 Clicks</th>
                 <th class={`text-center ${AuditsCol}`} scope="col">Updated At</th>
-                  <th scope="col">Url</th>
+                  <th class="text-center" scope="col">Url</th>
                 </tr>
               </thead>
               <tbody>
@@ -539,7 +539,7 @@ export const ItemModalContent = (props: Props) => {
             </div>
           </div>
         </div>
-               
+
         {/* Description */}
         <div class={`mt-4 text-muted ${Description}`}>{description()}</div>
 


### PR DESCRIPTION
The PR fixes #671 .
Support for displaying the reference architecture of projects if their design (blueprint) exists in Meshery's catalog.
Here is the attached screenshots and video for the feature.

![Screenshot from 2024-07-24 00-49-27](https://github.com/user-attachments/assets/552096b5-0be4-44ea-b8b9-b53541cb96f1)
![Screenshot from 2024-07-24 00-49-50](https://github.com/user-attachments/assets/538e1b2d-f09f-4600-96a3-4b7755f5efe3)
[Screencast from 2024-07-24 00-52-09.webm](https://github.com/user-attachments/assets/db65f3d1-e4c8-48e6-8ab4-befb7fa2e837)
