### PR TITLE
Fix additional categories ignored in zoom item modal and guide

### DIFF
--- a/ui/webapp/src/layout/guide/SubcategoryExtended.tsx
+++ b/ui/webapp/src/layout/guide/SubcategoryExtended.tsx
@@ -3,7 +3,7 @@ import trim from 'lodash/trim';
 import { createSignal, For, onMount, Show } from 'solid-js';
 
 import { FOUNDATION } from '../../data';
-import { BaseItem, Item } from '../../types';
+import { AdditionalCategory, BaseItem, Item } from '../../types';
 import sortItemsByOrderValue from '../../utils/sortItemsByOrderValue';
 import styles from './SubcategoryExtended.module.css';
 import SubcategoryGrid from './SubcategoryGrid';
@@ -21,7 +21,11 @@ const SubcategoryExtended = (props: Props) => {
 
   onMount(() => {
     const itemsInSubcategory = window.baseDS.items.filter(
-      (i: Item) => props.subcategory === i.subcategory && props.category === i.category
+      (i: Item) =>
+        (props.subcategory === i.subcategory && props.category === i.category) ||
+        i.additional_categories?.some(
+          (ac: AdditionalCategory) => ac.category === props.category && ac.subcategory === props.subcategory
+        )
     );
 
     if (!isUndefined(itemsInSubcategory) && itemsInSubcategory.length > 0) {

--- a/ui/webapp/src/utils/itemsDataGetter.ts
+++ b/ui/webapp/src/utils/itemsDataGetter.ts
@@ -598,8 +598,9 @@ export class ItemsDataGetter {
   public getItemsBySection(activeSection: ActiveSection): Item[] | undefined {
     if (this.ready && this.landscapeData && this.landscapeData.items) {
       return this.landscapeData.items.filter(
-        (i: Item) => activeSection.subcategory === i.subcategory && activeSection.category === i.category
-      );
+        (i: Item) => (activeSection.subcategory === i.subcategory && activeSection.category === i.category)
+          || i.additional_categories?.some((ac: AdditionalCategory) => ac.category === activeSection.category && ac.subcategory === activeSection.subcategory
+          ));
     }
   }
 

--- a/ui/webapp/src/utils/itemsDataGetter.ts
+++ b/ui/webapp/src/utils/itemsDataGetter.ts
@@ -598,9 +598,13 @@ export class ItemsDataGetter {
   public getItemsBySection(activeSection: ActiveSection): Item[] | undefined {
     if (this.ready && this.landscapeData && this.landscapeData.items) {
       return this.landscapeData.items.filter(
-        (i: Item) => (activeSection.subcategory === i.subcategory && activeSection.category === i.category)
-          || i.additional_categories?.some((ac: AdditionalCategory) => ac.category === activeSection.category && ac.subcategory === activeSection.subcategory
-          ));
+        (i: Item) =>
+          (activeSection.subcategory === i.subcategory && activeSection.category === i.category) ||
+          i.additional_categories?.some(
+            (ac: AdditionalCategory) =>
+              ac.category === activeSection.category && ac.subcategory === activeSection.subcategory
+          )
+      );
     }
   }
 


### PR DESCRIPTION
This fixes a bug where an item with additional categories was not displayed in the zoom item modal from a section other than its base category.