### PR TITLE
Fix encoding of spaces in badge

### DIFF
--- a/ui/common/src/data/data.ts
+++ b/ui/common/src/data/data.ts
@@ -1,5 +1,6 @@
 export const REGEX_DASH = /-/g;
 export const REGEX_URL = /^https?:\/\//;
 export const REGEX_UNDERSCORE = /_/g;
+export const REGEX_SPACE = /\s/g;
 
 export const BANNER_ID = 'banner-event';

--- a/ui/common/src/utils/formatShieldsBadgeContent.ts
+++ b/ui/common/src/utils/formatShieldsBadgeContent.ts
@@ -1,8 +1,12 @@
-import { REGEX_DASH } from '../data/data';
-// `badgeContent` message needs double dash instead of single dash,
-// due to single dash being used as a separator by shields.io
-
+import { REGEX_DASH, REGEX_UNDERSCORE, REGEX_SPACE } from '../data/data';
+// `badgeContent` message needs special character handling for shields.io:
+// - Single dash → double dash (dash is used as separator)
+// - Space → %20 (proper URL encoding)
+// - Underscore → double underscore (underscore renders as space in badge)
 // https://shields.io/badges/static-badge
 export const formatShieldsBadgeContent = (n: string): string => {
-  return n.replace(REGEX_DASH, '--');
+  return n
+    .replace(REGEX_DASH, '--')
+    .replace(REGEX_UNDERSCORE, '__')
+    .replace(REGEX_SPACE, '%20');
 };


### PR DESCRIPTION
Spaces in the foundation name leads to a broken badge, because spaces are not encoded.
This PR fixes this.

Original issue:
https://github.com/bundesverband-green-software/landscape/issues/47