### PR TITLE
Add CLI flags to make cache TTLs configurable

### DIFF
--- a/crates/cli/src/build/clomonitor.rs
+++ b/crates/cli/src/build/clomonitor.rs
@@ -7,9 +7,6 @@ use reqwest::StatusCode;
 
 use super::cache::Cache;
 
-/// How long the CLOMonitor data in the cache is valid (in days).
-const CLOMONITOR_CACHE_TTL: i64 = 7;
-
 /// Foundations supported by CLOMonitor.
 const SUPPORTED_FOUNDATIONS: [&str; 2] = ["cncf", "lfaidata"];
 
@@ -19,6 +16,7 @@ pub(crate) async fn fetch_report_summary(
     http_client: reqwest::Client,
     foundation: &str,
     project_name: &str,
+    clomonitor_cache_ttl: i64,
 ) -> Result<Option<Vec<u8>>> {
     // Check if the foundation provided is supported by CLOMonitor
     let foundation = foundation.to_lowercase();
@@ -30,7 +28,7 @@ pub(crate) async fn fetch_report_summary(
     let cache_file = format!("clomonitor_{foundation}_{project_name}.svg");
     if let Ok(Some((Some(modified_at), cached_report_summary))) = cache.read(&cache_file) {
         let modified_at: DateTime<Utc> = modified_at.into();
-        if Utc::now() - chrono::Duration::days(CLOMONITOR_CACHE_TTL) < modified_at {
+        if Utc::now() - chrono::Duration::days(clomonitor_cache_ttl) < modified_at {
             return Ok(Some(cached_report_summary));
         }
     }

--- a/crates/cli/src/build/crunchbase.rs
+++ b/crates/cli/src/build/crunchbase.rs
@@ -27,9 +27,6 @@ use super::{LandscapeData, cache::Cache};
 /// File used to cache data collected from Crunchbase.
 const CRUNCHBASE_CACHE_FILE: &str = "crunchbase.json";
 
-/// How long the Crunchbase data in the cache is valid (in days).
-const CRUNCHBASE_CACHE_TTL: i64 = 7;
-
 /// Environment variable containing the Crunchbase API key.
 const CRUNCHBASE_API_KEY: &str = "CRUNCHBASE_API_KEY";
 
@@ -42,6 +39,7 @@ const CRUNCHBASE_RATE_LIMITER_INTERVAL: Duration = Duration::from_millis(300);
 pub(crate) async fn collect_crunchbase_data(
     cache: &Cache,
     landscape_data: &LandscapeData,
+    crunchbase_cache_ttl: i64,
 ) -> Result<CrunchbaseData> {
     debug!("collecting organizations information from crunchbase (this may take a while)");
 
@@ -87,7 +85,7 @@ pub(crate) async fn collect_crunchbase_data(
             // Use cached data when available if it hasn't expired yet
             if let Some(cached_org) = cached_data.as_ref().and_then(|cache| {
                 cache.get(&url).and_then(|org| {
-                    if org.generated_at + chrono::Duration::days(CRUNCHBASE_CACHE_TTL) > Utc::now() {
+                    if org.generated_at + chrono::Duration::days(crunchbase_cache_ttl) > Utc::now() {
                         Some(org)
                     } else {
                         None

--- a/crates/cli/src/build/github.rs
+++ b/crates/cli/src/build/github.rs
@@ -25,16 +25,17 @@ use super::{LandscapeData, cache::Cache};
 /// File used to cache data collected from GitHub.
 const GITHUB_CACHE_FILE: &str = "github.json";
 
-/// How long the GitHub data in the cache is valid (in days).
-const GITHUB_CACHE_TTL: i64 = 7;
-
 /// Environment variable containing a comma separated list of GitHub tokens.
 const GITHUB_TOKENS: &str = "GITHUB_TOKENS";
 
 /// Collect GitHub data for each of the items repositories in the landscape,
 /// reusing cached data whenever possible.
 #[instrument(skip_all, err)]
-pub(crate) async fn collect_github_data(cache: &Cache, landscape_data: &LandscapeData) -> Result<GithubData> {
+pub(crate) async fn collect_github_data(
+    cache: &Cache,
+    landscape_data: &LandscapeData,
+    github_cache_ttl: i64,
+) -> Result<GithubData> {
     debug!("collecting repositories information from github (this may take a while)");
 
     // Read cached data (if available)
@@ -92,7 +93,7 @@ pub(crate) async fn collect_github_data(cache: &Cache, landscape_data: &Landscap
             // Use cached data when available if it hasn't expired yet
             if let Some(cached_repo) = cached_data.as_ref().and_then(|cache| {
                 cache.get(&url).and_then(|repo| {
-                    if repo.generated_at + chrono::Duration::days(GITHUB_CACHE_TTL) > Utc::now() {
+                    if repo.generated_at + chrono::Duration::days(github_cache_ttl) > Utc::now() {
                         Some(repo)
                     } else {
                         None


### PR DESCRIPTION
## Summary

- Add `--github-cache-ttl`, `--crunchbase-cache-ttl`, and `--clomonitor-cache-ttl` CLI arguments to the `build` command
- All three default to 7 days, preserving full backward compatibility
- Removes hardcoded `*_CACHE_TTL` constants in favor of configurable parameters passed through the call chain

## Motivation

Currently the cache TTL for GitHub, Crunchbase, and CLOMonitor data is hardcoded to 7 days. This makes it impossible to force a refresh of stale data without clearing the entire cache directory. Adding configurable TTLs gives operators control over data freshness — useful for CI/CD pipelines that need up-to-date data or development environments that want longer caching.

Closes #914

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] Running without any new flags defaults to 7-day TTL (backward compatible)
- [ ] Running with `--github-cache-ttl 1` uses 1-day TTL for GitHub data
- [ ] `cargo clippy` clean (requires full build environment with wasm-pack + yarn)