### PR TITLE
Hide search bar on Guide pages where search is non-functional

### DIFF
--- a/ui/webapp/src/layout/navigation/Header.tsx
+++ b/ui/webapp/src/layout/navigation/Header.tsx
@@ -136,44 +136,47 @@ const Header = (props: Props) => {
             </Show>
           </div>
 
-          <div class={`d-flex flex-row align-items-center ms-auto mt-0 ${styles.searchWrapper}`}>
-            <div class="position-relative me-4 w-100">
-              <Searchbar searchBarClass={`${styles.searchBar}`} device="desktop" />
-            </div>
+          <Show when={!location.pathname.startsWith(GUIDE_PATH)}>
+  <div class={`d-flex flex-row align-items-center ms-auto mt-0 ${styles.searchWrapper}`}>
+    <div class="position-relative me-4 w-100">
+      <Searchbar searchBarClass={`${styles.searchBar}`} device="desktop" />
+    </div>
 
-            <div class={`d-flex align-items-center ${styles.icons}`}>
-              <EmbedModal />
-              <DownloadDropdown />
-              <Show when={!isUndefined(window.baseDS.games_available)}>
-                <button
-                  class={`btn btn-md text-dark ms-3 px-0 ${styles.btnLink}`}
-                  onClick={() => {
-                    navigate(prepareLink(GAMES_PATH), {
-                      state: { from: 'header' },
-                    });
-                    scrollToTop(false);
-                  }}
-                  aria-label='Go to "Games" page'
-                >
-                  <SVGIcon kind={SVGIconKind.Games} class={`position-relative ${styles.linkIcon}`} />
-                </button>
-              </Show>
-              <Show
-                when={
-                  !isUndefined(window.baseDS.header) &&
-                  !isUndefined(window.baseDS.header!.links) &&
-                  !isUndefined(window.baseDS.header!.links!.github)
-                }
-              >
-                <ExternalLink
-                  class={`btn btn-md text-dark ms-3 px-0 ${styles.btnLink}`}
-                  href={window.baseDS.header!.links!.github!}
-                >
-                  <SVGIcon kind={SVGIconKind.GitHub} class={`position-relative ${styles.linkIcon}`} />
-                </ExternalLink>
-              </Show>
-            </div>
-          </div>
+    <div class={`d-flex align-items-center ${styles.icons}`}>
+      <EmbedModal />
+      <DownloadDropdown />
+      <Show when={!isUndefined(window.baseDS.games_available)}>
+        <button
+          class={`btn btn-md text-dark ms-3 px-0 ${styles.btnLink}`}
+          onClick={() => {
+            navigate(prepareLink(GAMES_PATH), {
+              state: { from: 'header' },
+            });
+            scrollToTop(false);
+          }}
+          aria-label='Go to "Games" page'
+        >
+          <SVGIcon kind={SVGIconKind.Games} class={`position-relative ${styles.linkIcon}`} />
+        </button>
+      </Show>
+      <Show
+        when={
+          !isUndefined(window.baseDS.header) &&
+          !isUndefined(window.baseDS.header!.links) &&
+          !isUndefined(window.baseDS.header!.links!.github)
+        }
+      >
+        <ExternalLink
+          class={`btn btn-md text-dark ms-3 px-0 ${styles.btnLink}`}
+          href={window.baseDS.header!.links!.github!}
+        >
+          <SVGIcon kind={SVGIconKind.GitHub} class={`position-relative ${styles.linkIcon}`} />
+        </ExternalLink>
+      </Show>
+    </div>
+  </div>
+</Show>
+
         </Show>
       </div>
     </header>

--- a/ui/webapp/src/layout/navigation/MobileHeader.tsx
+++ b/ui/webapp/src/layout/navigation/MobileHeader.tsx
@@ -84,26 +84,28 @@ const MobileHeader = (props: Props) => {
                 <Image class={styles.qr} name="QR code" logo={window.baseDS.qr_code!} />
               </Show>
             }
-          >
-            <div class={`d-flex flex-row align-items-center mt-3 mt-md-4 ${styles.searchWrapper}`}>
-              <div class="position-relative w-100">
-                <Searchbar device="mobile" />
-              </div>
-              <div class="d-none d-lg-flex align-items-center">
-                <DownloadDropdown />
-                <Show
-                  when={
-                    !isUndefined(window.baseDS.header) &&
-                    !isUndefined(window.baseDS.header!.links) &&
-                    !isUndefined(window.baseDS.header!.links!.github)
-                  }
-                >
-                  <ExternalLink class="btn btn-md text-dark fs-5 ms-2 px-0" href={window.baseDS.header!.links!.github!}>
-                    <SVGIcon kind={SVGIconKind.GitHub} class={`position-relative ${styles.githubIcon}`} />
-                  </ExternalLink>
-                </Show>
-              </div>
-            </div>
+          ><Show when={!location.pathname.startsWith('/guide')}>
+  <div class={`d-flex flex-row align-items-center mt-3 mt-md-4 ${styles.searchWrapper}`}>
+    <div class="position-relative w-100">
+      <Searchbar device="mobile" />
+    </div>
+    <div class="d-none d-lg-flex align-items-center">
+      <DownloadDropdown />
+      <Show
+        when={
+          !isUndefined(window.baseDS.header) &&
+          !isUndefined(window.baseDS.header!.links) &&
+          !isUndefined(window.baseDS.header!.links!.github)
+        }
+      >
+        <ExternalLink class="btn btn-md text-dark fs-5 ms-2 px-0" href={window.baseDS.header!.links!.github!}>
+          <SVGIcon kind={SVGIconKind.GitHub} class={`position-relative ${styles.githubIcon}`} />
+        </ExternalLink>
+      </Show>
+    </div>
+  </div>
+</Show>
+
           </Show>
         </div>
       </header>


### PR DESCRIPTION
The search bar is currently displayed on Guide pages, but it only searches
Explore ecosystem items and does not search Guide content.

This can confuse users because valid Guide page text (e.g., "segmentation")
does not return results.

This PR hides the search bar on Guide pages to prevent confusion and
align UI behavior with actual search functionality.

Changes:
- Wrapped Searchbar in Header.tsx with a route condition
- Applied the same condition in MobileHeader.tsx

Tested:
- Search visible on Explore page
- Search hidden on Guide pages
- Desktop and mobile verified
