### PR TITLE
Hide archived projects from default landscape view

### DIFF
--- a/ui/webapp/src/utils/filterData.ts
+++ b/ui/webapp/src/utils/filterData.ts
@@ -5,8 +5,8 @@ import { ActiveFilters, FilterCategory, Item, Repository } from '../types';
 import getFoundationNameLabel from './getFoundationNameLabel';
 
 const filterData = (items: Item[], activeFilters: ActiveFilters): Item[] => {
-  if (Object.keys(activeFilters).length > 0) {
-    const filteredItems: Item[] = items.filter((item: Item) => {
+  const filteredItems: Item[] = items.filter((item: Item) => {
+    if (Object.keys(activeFilters).length > 0) {
       // Filter Extra
       if (activeFilters[FilterCategory.Extra]) {
         if (
@@ -107,30 +107,32 @@ const filterData = (items: Item[], activeFilters: ActiveFilters): Item[] => {
           return false;
         }
       }
+    }
 
-      //  Maturity filter
-      if (activeFilters[FilterCategory.Maturity]) {
-        if (
-          isUndefined(item.maturity) &&
-          !activeFilters[FilterCategory.Maturity].includes(`non-${getFoundationNameLabel()}`)
-        ) {
-          return false;
-        } else {
-          if (!isUndefined(item.maturity)) {
-            if (!activeFilters[FilterCategory.Maturity].includes(item.maturity)) {
-              return false;
-            }
+    //  Maturity filter
+    if (activeFilters[FilterCategory.Maturity]) {
+      if (
+        isUndefined(item.maturity) &&
+        !activeFilters[FilterCategory.Maturity].includes(`non-${getFoundationNameLabel()}`)
+      ) {
+        return false;
+      } else {
+        if (!isUndefined(item.maturity)) {
+          if (!activeFilters[FilterCategory.Maturity].includes(item.maturity)) {
+            return false;
           }
         }
       }
+    } else if (!isUndefined(item.maturity) && item.maturity === 'archived') {
+      // Archived items are hidden from the default landscape view unless the
+      // user explicitly opts in via the Maturity filter.
+      return false;
+    }
 
-      return true;
-    });
+    return true;
+  });
 
-    return filteredItems;
-  } else {
-    return items;
-  }
+  return filteredItems;
 };
 
 export default filterData;

--- a/ui/webapp/src/utils/itemsDataGetter.ts
+++ b/ui/webapp/src/utils/itemsDataGetter.ts
@@ -618,9 +618,7 @@ export class ItemsDataGetter {
   public queryItems(input: ActiveFilters, activeGroup: string, classify: ClassifyOption) {
     const allGroupedItems = this.getGroupedData();
     // Filter only the active group
-    const filteredItems = !isEmpty(input)
-      ? filterData(allGroupedItems[activeGroup], input)
-      : allGroupedItems[activeGroup];
+    const filteredItems = filterData(allGroupedItems[activeGroup], input);
     const groupedItems = { ...allGroupedItems, [activeGroup]: filteredItems };
 
     let activeCategoryFilters: string[] | undefined;


### PR DESCRIPTION
Archived items were shown by default because queryItems() skipped all filtering when no filters were active. 
Now filterData always runs and excludes archived items unless the user explicitly selects 'archived' in the Maturity filter.

Fixes #949